### PR TITLE
Fix dupicate username.

### DIFF
--- a/app/authenticators/gub.js
+++ b/app/authenticators/gub.js
@@ -41,7 +41,6 @@ export default Base.extend({
 						token: token,
 						username: response.user.username,
 						name: response.user.name,
-						username: response.user.username,
 						userid: response.user.id,
             			can_delete_published : Ember.$.inArray('delete_published', response.user.role.rights) !== -1,
         				can_biblreview : Ember.$.inArray('biblreview', response.user.role.rights) !== -1,


### PR DESCRIPTION
This bug made the site crash in IE11, in strict mode.
Solution: Simply removed the second username.