### PR TITLE
Adding the Swepub output code of critical-edition

### DIFF
--- a/app/oai_documents/mods.rb
+++ b/app/oai_documents/mods.rb
@@ -375,7 +375,7 @@ class OaiDocuments
        'other' => ['ovr', 'vet', 'publication/other'],
        'publication_review-article' => ['for', 'ref', 'publication/review-article'],
        'artistic-work_scientific_and_development' => ['kfu', 'vet', 'artistic-work'], # ?????
-       'publication_textcritical-edition' => ['sam', 'vet', 'publication/edited-book'],
+       'publication_textcritical-edition' => ['ovr', 'vet', 'publication/critical-edition'],
        'publication_textbook' => ['bok', 'vet', 'publication/book'],
        'artistic-work_original-creative-work' => ['kfu', 'vet', 'artistic-work/original-creative-work'],
        'publication_editorial-letter' => ['art', 'vet', 'publication/editorial-letter'],


### PR DESCRIPTION
With this change consumers of GUP OAI-PMH records
will be able to separate *Textkritisk utgåva* from
*Samlingsverk(redaktörskap)*. Before this change the records
corresponding to text critical editions were labeled
*publication/edited-book* in the OAI-PMH output.

Records of textcritical-edition in GUP will now have the code
**publication/critical-edition** and the publication-type
**ovr/vet** as specified in the document
*Swepub output - types, codes and mapping (2019-09-20)*.