### PR TITLE
Remove the links for editing people and org in GUP.

### DIFF
--- a/frontend/app/router.js
+++ b/frontend/app/router.js
@@ -30,17 +30,17 @@ Router.map(function() {
     });
   });
   this.route('admin', function() {
-    this.route('departments', function(){
-      this.route('index', {path: '/'});
-      this.route('new');
-    });
-    this.route('people', function() {
-      this.route('person', function() {
-        this.route('edit', {path: 'edit/:id'}, function() {
-          this.route('list', {path: '/'});
-        });
-      });
-    });
+    // this.route('departments', function(){
+    //   this.route('index', {path: '/'});
+    //   this.route('new');
+    // });
+    // this.route('people', function() {
+    //   this.route('person', function() {
+    //     this.route('edit', {path: 'edit/:id'}, function() {
+    //       this.route('list', {path: '/'});
+    //     });
+    //   });
+    // });
 
     this.route('messages');
   });

--- a/frontend/app/templates/admin.hbs
+++ b/frontend/app/templates/admin.hbs
@@ -3,8 +3,6 @@
 	  <div class="col-xs-12">
 	    <nav id="sub-nav">
 	      	<ul class="nav">
-				<li>{{#link-to 'admin.people' (query-params qp='') current-when="admin.people"}}{{t 'admin.admin_people'}}{{/link-to}}</li>
-				<li>{{#link-to 'admin.departments.index' (query-params qd='') current-when="admin.departments"}}{{t 'admin.admin_departments'}}{{/link-to}}</li>
 				<li>{{#link-to 'admin.messages' id='admin-messages-link'}}{{t 'admin.admin_messages'}}{{/link-to}}</li>
 			</ul>
 	    </nav>


### PR DESCRIPTION
The pages are technically still in the code, but the route and links are removed.

The routes are just commented out, still in place in case they're wanted.
