### PR TITLE
support for OA-links 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Ignore bundler config.
 /.bundle
 
+# Ignore VSCode settings
+.vscode/
+
 # Ignore the default SQLite database.
 /db/*.sqlite3
 /db/*.sqlite3-journal

--- a/app/controllers/v1/drafts_controller.rb
+++ b/app/controllers/v1/drafts_controller.rb
@@ -358,7 +358,7 @@ class V1::DraftsController < V1::V1Controller
   end
 
   def publication_link_permitted_params(params)
-    params.require(:publication_link).permit(:url, :position, :publication_version_id)
+    params.require(:publication_link).permit(:url, :oa, :position, :publication_version_id)
   end
 
   # Creates connections between people, departments and publications for a publication and a people array

--- a/app/controllers/v1/drafts_controller.rb
+++ b/app/controllers/v1/drafts_controller.rb
@@ -324,9 +324,6 @@ class V1::DraftsController < V1::V1Controller
       params[:publication][:publication_links].each do |publication_link|
       #@TODO: if not params[:publication][:publication_links].kind_of?(Array) #respond_to?('each') #trow exception
         publication_link[:publication_version_id] = publication_version.id
-        # attribute is_oa has to be renamed to oa, attribute checked_at has to be renamed to checked_at
-        publication_link[:oa] = publication_link.delete(:is_oa) if publication_link.key?(:is_oa)
-        publication_link[:checked_at] = publication_link.delete(:checked_at) if publication_link.key?(:checked_at)
         p publication_link
         #TODO: publication_version.create_publication_link
         pl = PublicationLink.create(
@@ -346,7 +343,7 @@ class V1::DraftsController < V1::V1Controller
   end
 
   def publication_link_permitted_params(params)
-    params.require(:publication_link).permit(:url, :oa, :checked_at, :position, :publication_version_id)
+    params.require(:publication_link).permit(:url, :is_oa, :checked_at, :position, :publication_version_id)
   end
 
   # Creates connections between people, departments and publications for a publication and a people array

--- a/app/controllers/v1/drafts_controller.rb
+++ b/app/controllers/v1/drafts_controller.rb
@@ -79,7 +79,6 @@ class V1::DraftsController < V1::V1Controller
           ))
         end
         create_publication_identifiers!(publication_version: pub.current_version)
-        prepare_doi_link
         create_publication_links!(publication_version: pub.current_version)
 
         create_authors_admin!(publication_version: pub.current_version)
@@ -93,20 +92,6 @@ class V1::DraftsController < V1::V1Controller
       render_json(201)
     end
   end
-
-  def prepare_doi_link
-    params[:publication][:publication_links] = [] if !params[:publication][:publication_links]
-
-    if params[:publication][:publication_identifiers]
-      params[:publication][:publication_identifiers].each do |publication_identifier|
-        if publication_identifier[:identifier_code].eql?('doi')
-          doi_url_prefix = 'https://doi.org/'
-          params[:publication][:publication_links] << {url: doi_url_prefix + publication_identifier[:identifier_value]}
-        end
-      end
-    end
-  end
-
 
   def create_authors_admin!(publication_version:)
     if params[:publication][:authors]

--- a/app/controllers/v1/drafts_controller.rb
+++ b/app/controllers/v1/drafts_controller.rb
@@ -324,6 +324,9 @@ class V1::DraftsController < V1::V1Controller
       params[:publication][:publication_links].each do |publication_link|
       #@TODO: if not params[:publication][:publication_links].kind_of?(Array) #respond_to?('each') #trow exception
         publication_link[:publication_version_id] = publication_version.id
+        # attribute is_oa has to be renamed to oa, attribute checked_at has to be renamed to checked_at
+        publication_link[:oa] = publication_link.delete(:is_oa) if publication_link.key?(:is_oa)
+        publication_link[:checked_at] = publication_link.delete(:checked_at) if publication_link.key?(:checked_at)
         p publication_link
         #TODO: publication_version.create_publication_link
         pl = PublicationLink.create(
@@ -343,7 +346,7 @@ class V1::DraftsController < V1::V1Controller
   end
 
   def publication_link_permitted_params(params)
-    params.require(:publication_link).permit(:url, :oa, :position, :publication_version_id)
+    params.require(:publication_link).permit(:url, :oa, :checked_at, :position, :publication_version_id)
   end
 
   # Creates connections between people, departments and publications for a publication and a people array

--- a/app/controllers/v1/published_publications_controller.rb
+++ b/app/controllers/v1/published_publications_controller.rb
@@ -139,7 +139,7 @@ class V1::PublishedPublicationsController < ApplicationController
       return
     end
 
-    @response = generic_pagination(resource: publications, resource_name: 'publications', page: params[:page], additional_order: sort_order, options: {include_authors: true, brief: true})
+    @response = generic_pagination(resource: publications, resource_name: 'publications', page: params[:page], additional_order: sort_order, options: {include_authors: true})
     render_json(200)
   end
 
@@ -236,8 +236,8 @@ class V1::PublishedPublicationsController < ApplicationController
   end
 
   def merge_publication_links(publication)
-    existing = publication.current_version.publication_links.order(id: :desc).map{|p|{url: p.url, position: p.position}}
-    incoming = params[:publication][:publication_links].map{|p|{url: p[:url], position: p[:position]}}
+    existing = publication.current_version.publication_links.order(id: :desc).map{|p|{url: p.url, oa: p.oa, position: p.position}}
+    incoming = params[:publication][:publication_links].map{|p|{url: p[:url], oa: p[:oa], position: p[:position]}}
     existing.each do |existing_link|
       if !incoming.any?{|incoming_link|incoming_link[:url].eql?(existing_link[:url])}
         incoming << existing_link
@@ -478,7 +478,7 @@ class V1::PublishedPublicationsController < ApplicationController
   end
 
   def publication_link_permitted_params(params)
-    params.require(:publication_link).permit(:url, :position, :publication_version_id)
+    params.require(:publication_link).permit(:url, :oa, :position, :publication_version_id)
   end
 
   def permitted_params(params)

--- a/app/controllers/v1/published_publications_controller.rb
+++ b/app/controllers/v1/published_publications_controller.rb
@@ -458,22 +458,34 @@ class V1::PublishedPublicationsController < ApplicationController
   end
 
   def create_publication_links(publication_version:)
-    if params[:publication][:publication_links].present?
-      params[:publication][:publication_links].each do |publication_link|
-      #@TODO: if not params[:publication][:publication_links].kind_of?(Array) #respond_to?('each') #trow exception
-        publication_link[:publication_version_id] = publication_version.id
-        #TODO: publication_version.create_publication_link
-        pl = PublicationLink.create(
-          publication_link_permitted_params(
-            ActionController::Parameters.new(publication_link: publication_link)
-          )
-        )
-        if pl.errors.any?
-          #TODO: Right now not correct field key in errors message (should be "publication_links")?
-          error_msg(ErrorCodes::VALIDATION_ERROR, I18n.t("publication_links.errors.create_error"), pl.errors)
-          render_json
-          raise ActiveRecord::Rollback
+    params[:publication][:publication_links] = [] if params[:publication][:publication_links].nil?
+
+    # Create a DOI link if publication identifier with code 'doi' exists and no link contains the DOI value as a substring
+    if params[:publication][:publication_identifiers]
+      params[:publication][:publication_identifiers].each do |publication_identifier|
+        if publication_identifier[:identifier_code].eql?('doi')
+          unless params[:publication][:publication_links].any? { |link| link[:url].include?(publication_identifier[:identifier_value]) }
+            doi_url_prefix = 'https://doi.org/'
+            params[:publication][:publication_links] << {url: doi_url_prefix + publication_identifier[:identifier_value]}
+          end
         end
+      end
+    end
+
+    params[:publication][:publication_links].each do |publication_link|
+    #@TODO: if not params[:publication][:publication_links].kind_of?(Array) #respond_to?('each') #trow exception
+      publication_link[:publication_version_id] = publication_version.id
+      #TODO: publication_version.create_publication_link
+      pl = PublicationLink.create(
+        publication_link_permitted_params(
+          ActionController::Parameters.new(publication_link: publication_link)
+        )
+      )
+      if pl.errors.any?
+        #TODO: Right now not correct field key in errors message (should be "publication_links")?
+        error_msg(ErrorCodes::VALIDATION_ERROR, I18n.t("publication_links.errors.create_error"), pl.errors)
+        render_json
+        raise ActiveRecord::Rollback
       end
     end
   end

--- a/app/controllers/v1/published_publications_controller.rb
+++ b/app/controllers/v1/published_publications_controller.rb
@@ -236,8 +236,8 @@ class V1::PublishedPublicationsController < ApplicationController
   end
 
   def merge_publication_links(publication)
-    existing = publication.current_version.publication_links.order(id: :desc).map{|p|{url: p.url, oa: p.oa, position: p.position}}
-    incoming = params[:publication][:publication_links].map{|p|{url: p[:url], oa: p[:oa], position: p[:position]}}
+    existing = publication.current_version.publication_links.order(id: :desc).map{|p|{url: p.url, is_oa: p.is_oa, position: p.position}}
+    incoming = params[:publication][:publication_links].map{|p|{url: p[:url], is_oa: p[:is_oa], position: p[:position]}}
     existing.each do |existing_link|
       if !incoming.any?{|incoming_link|incoming_link[:url].eql?(existing_link[:url])}
         incoming << existing_link
@@ -479,7 +479,7 @@ class V1::PublishedPublicationsController < ApplicationController
   end
 
   def publication_link_permitted_params(params)
-    params.require(:publication_link).permit(:url, :oa, :position, :publication_version_id)
+    params.require(:publication_link).permit(:url, :is_oa, :position, :publication_version_id)
   end
 
   def permitted_params(params)

--- a/app/controllers/v1/published_publications_controller.rb
+++ b/app/controllers/v1/published_publications_controller.rb
@@ -425,6 +425,7 @@ class V1::PublishedPublicationsController < ApplicationController
       # TODO! This needs error handling, or saving a publication will cause GUP to crash.
       Thread.new {
         ActiveRecord::Base.connection_pool.with_connection do
+          Unpaywall.check_oa_status(publication)
           GupAdminPublication.put_to_index(publication.id)
         end
       }

--- a/app/models/publication_version.rb
+++ b/app/models/publication_version.rb
@@ -4,7 +4,7 @@ class PublicationVersion < ActiveRecord::Base
   belongs_to :publication
   belongs_to :publication_type
   has_many :publication_identifiers, autosave: true
-  has_many :publication_links
+  has_many :publication_links, -> { order(position: :asc) }
   has_many :people2publications, -> { order(position: :asc) }
   has_many :authors, :through => :people2publications, :source => :person
   has_many :departments, :through => :people2publications

--- a/app/models/unpaywall.rb
+++ b/app/models/unpaywall.rb
@@ -63,7 +63,7 @@ class Unpaywall < ActiveRecord::Base
 
     links = publication.current_version.publication_links
 
-    email = ENV["UNPAYWALL_EMAIL"] || "gup@ub.gu.se"
+    email = ENV["UNPAYWALL_EMAIL"]
     links.each do |link|
         puts "Checking OA-status for =#{link.url}"
         next if link.is_oa == true

--- a/app/models/unpaywall.rb
+++ b/app/models/unpaywall.rb
@@ -1,0 +1,88 @@
+require "net/http"
+require "json"
+require "uri"
+require "cgi"
+
+class Unpaywall < ActiveRecord::Base
+  def self.extract_doi(raw_url)
+    return nil if raw_url.blank?
+
+    s = CGI.unescapeHTML(raw_url.to_s.dup)
+
+    2.times do
+      decoded = CGI.unescape(s)
+      break if decoded == s
+
+      s = decoded
+    end
+
+    match = s.match(%r{(10\.\d+/[^\s\?#&<>"']+)}i)
+    return nil unless match
+
+    doi = match[1]
+    doi = doi.sub(/[)\].,;:]+\z/, "")
+
+    doi.presence
+  end
+
+  def self.oa_status_for_url(url, email:)
+    doi = extract_doi(url)
+    return "unknown" if doi.blank?
+
+    oa_status_for_doi(doi, email: email)
+  end
+
+  def self.oa_status_for_doi(doi, email:)
+    encoded_doi = URI.encode_www_form_component(doi)
+    uri = URI("https://api.unpaywall.org/v2/#{encoded_doi}")
+    uri.query = URI.encode_www_form(email: email)
+
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    http.open_timeout = 15
+    http.read_timeout = 15
+
+    req = Net::HTTP::Get.new(uri.request_uri)
+    req["Accept"] = "application/json"
+
+    res = http.request(req)
+
+    return "unknown" if res.code.to_i == 404
+    return "error" unless res.is_a?(Net::HTTPSuccess)
+
+    body = JSON.parse(res.body)
+    body["is_oa"] == true
+  rescue StandardError => e
+    Rails.logger.warn(
+      "Unpaywall lookup failed for DOI #{doi.inspect}: #{e.class}: #{e.message}"
+    )
+    "error"
+  end
+
+  def self.check_oa_status(publication)
+
+    links = publication.current_version.publication_links
+    puts "¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤"
+    puts publication.id
+    puts "¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤"
+
+    email = ENV["UNPAYWALL_EMAIL"] || "gup@ub.gu.se"
+    links.each do |link|
+        puts "Checking OA-status for =#{link.url}"
+        next if link.oa == true
+        oa_status = Unpaywall.oa_status_for_url(link.url, email: email)
+        next if oa_status == "error"
+        now = Time.current
+
+        case oa_status
+        when true
+          link.update_columns(oa: true, checked_at: now)
+        when false
+          link.update_columns(oa: false, checked_at: now)
+        when "unknown"
+          link.update_columns(checked_at: now)
+        end
+    end
+    end
+
+end

--- a/app/models/unpaywall.rb
+++ b/app/models/unpaywall.rb
@@ -62,14 +62,11 @@ class Unpaywall < ActiveRecord::Base
   def self.check_oa_status(publication)
 
     links = publication.current_version.publication_links
-    puts "¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤"
-    puts publication.id
-    puts "¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤"
 
     email = ENV["UNPAYWALL_EMAIL"] || "gup@ub.gu.se"
     links.each do |link|
         puts "Checking OA-status for =#{link.url}"
-        next if link.oa == true
+        next if link.is_oa == true
         oa_status = Unpaywall.oa_status_for_url(link.url, email: email)
         next if oa_status == "error"
         now = Time.current
@@ -78,7 +75,7 @@ class Unpaywall < ActiveRecord::Base
         when true
           link.update_columns(oa: true, checked_at: now)
         when false
-          link.update_columns(oa: false, checked_at: now)
+          link.update_columns(is_oa: false, checked_at: now)
         when "unknown"
           link.update_columns(checked_at: now)
         end

--- a/app/models/unpaywall.rb
+++ b/app/models/unpaywall.rb
@@ -73,7 +73,7 @@ class Unpaywall < ActiveRecord::Base
 
         case oa_status
         when true
-          link.update_columns(oa: true, checked_at: now)
+          link.update_columns(is_oa: true, checked_at: now)
         when false
           link.update_columns(is_oa: false, checked_at: now)
         when "unknown"

--- a/app/oai_documents/mods.rb
+++ b/app/oai_documents/mods.rb
@@ -244,7 +244,11 @@ class OaiDocuments
             xml.tag!("url", publication.current_version.url, 'displayLabel' => 'FULLTEXT')
           end
         end
-
+        #### Access Condition ####
+        # If any of the publication links is open access, mark the publication as open access
+        if publication.current_version.publication_links.where(oa: true).any?
+          xml.tag!("accessCondition", "gratis", 'authority' => 'kb.se', 'valueURI' => 'https://id.kb.se/policy/oa/gratis')
+        end
 
         #### Physical description ####
         # TODO: Asset model should be extended to make possible to describe each file better, to decide if it's fulltext or not

--- a/app/oai_documents/mods.rb
+++ b/app/oai_documents/mods.rb
@@ -246,7 +246,7 @@ class OaiDocuments
         end
         #### Access Condition ####
         # If any of the publication links is open access, mark the publication as open access
-        if publication.current_version.publication_links.where(oa: true).any?
+        if publication.current_version.publication_links.where(is_oa: true).any?
           xml.tag!("accessCondition", "gratis", 'authority' => 'kb.se', 'valueURI' => 'https://id.kb.se/policy/oa/gratis')
         end
 

--- a/config/initializers/setup_publication_json_view.rb
+++ b/config/initializers/setup_publication_json_view.rb
@@ -11,6 +11,18 @@ def setup_publication_json_views
           ON pv.id = pi.publication_version_id
        GROUP BY pub.id
       ;
+
+      DROP VIEW IF EXISTS v_publications_v_publication_links CASCADE;
+      CREATE OR REPLACE VIEW v_publications_v_publication_links AS
+      SELECT pub.id AS publication_id,
+             json_agg(json_build_object('publication_version_id', pl.id, 'url', pl.url, 'oa', pl.oa, 'checked_at', pl.checked_at, 'position', pl.position)) AS links
+        FROM publications pub
+        JOIN publication_versions pv
+          ON pub.current_version_id = pv.id
+        JOIN publication_links pl
+          ON pv.id = pl.publication_version_id
+       GROUP BY pub.id
+      ;
       
       DROP VIEW IF EXISTS v_publications_v_people_identifiers CASCADE;
       CREATE OR REPLACE VIEW v_publications_v_people_identifiers AS
@@ -183,6 +195,7 @@ def setup_publication_json_views
                'version_updated_at', pv.updated_at,
                'version_updated_by', pv.updated_by,
                'publication_identifiers', COALESCE(pi.identifiers, '[]'),
+               'publication_links', COALESCE(pl.links, '[]'),
                'authors', a.authors,
                'categories', COALESCE(pc.categories, '[]'),
                'series', COALESCE(s.series, '[]'),
@@ -200,6 +213,8 @@ def setup_publication_json_views
           ON pub.id = a.publication_id
         LEFT JOIN v_publications_v_publication_identifiers pi
           ON pub.id = pi.publication_id
+        LEFT JOIN v_publications_v_publication_links pl
+          ON pub.id = pl.publication_id
         LEFT JOIN v_publications_v_publication_categories pc
           ON pub.id = pc.publication_id
         LEFT JOIN v_publications_v_series s

--- a/config/initializers/setup_publication_json_view.rb
+++ b/config/initializers/setup_publication_json_view.rb
@@ -15,7 +15,7 @@ def setup_publication_json_views
       DROP VIEW IF EXISTS v_publications_v_publication_links CASCADE;
       CREATE OR REPLACE VIEW v_publications_v_publication_links AS
       SELECT pub.id AS publication_id,
-             json_agg(json_build_object('publication_version_id', pl.id, 'url', pl.url, 'is_oa', pl.oa, 'checked_at', pl.checked_at, 'position', pl.position)) AS links
+             json_agg(json_build_object('publication_version_id', pl.id, 'url', pl.url, 'is_oa', pl.is_oa, 'checked_at', pl.checked_at, 'position', pl.position)) AS links
         FROM publications pub
         JOIN publication_versions pv
           ON pub.current_version_id = pv.id

--- a/config/initializers/setup_publication_json_view.rb
+++ b/config/initializers/setup_publication_json_view.rb
@@ -15,7 +15,7 @@ def setup_publication_json_views
       DROP VIEW IF EXISTS v_publications_v_publication_links CASCADE;
       CREATE OR REPLACE VIEW v_publications_v_publication_links AS
       SELECT pub.id AS publication_id,
-             json_agg(json_build_object('publication_version_id', pl.id, 'url', pl.url, 'oa', pl.oa, 'checked_at', pl.checked_at, 'position', pl.position)) AS links
+             json_agg(json_build_object('publication_version_id', pl.id, 'url', pl.url, 'is_oa', pl.oa, 'checked_at', pl.checked_at, 'position', pl.position)) AS links
         FROM publications pub
         JOIN publication_versions pv
           ON pub.current_version_id = pv.id

--- a/db/migrate/20260112114317_add_oa_to_publication_links.rb
+++ b/db/migrate/20260112114317_add_oa_to_publication_links.rb
@@ -1,0 +1,5 @@
+class AddOaToPublicationLinks < ActiveRecord::Migration
+  def change
+    add_column :publication_links, :oa, :boolean: default: false
+  end
+end

--- a/db/migrate/20260112114317_add_oa_to_publication_links.rb
+++ b/db/migrate/20260112114317_add_oa_to_publication_links.rb
@@ -1,5 +1,5 @@
 class AddOaToPublicationLinks < ActiveRecord::Migration
   def change
-    add_column :publication_links, :oa, :boolean: default: false
+    add_column :publication_links, :oa, :boolean, default: false
   end
 end

--- a/db/migrate/20260113140920_add_has_oa_to_publication_types.rb
+++ b/db/migrate/20260113140920_add_has_oa_to_publication_types.rb
@@ -1,5 +1,5 @@
 class AddHasOaToPublicationTypes < ActiveRecord::Migration
   def change
-    add_column :publication_types, :has_open_access, :boolean, default: true
+    add_column :publication_types, :has_open_access, :boolean default: true
   end
 end

--- a/db/migrate/20260113140920_add_has_oa_to_publication_types.rb
+++ b/db/migrate/20260113140920_add_has_oa_to_publication_types.rb
@@ -1,0 +1,5 @@
+class AddHasOaToPublicationTypes < ActiveRecord::Migration
+  def change
+    add_column :publication_types, :has_open_access, :boolean, default: true
+  end
+end

--- a/db/migrate/20260113140920_add_has_oa_to_publication_types.rb
+++ b/db/migrate/20260113140920_add_has_oa_to_publication_types.rb
@@ -1,5 +1,5 @@
 class AddHasOaToPublicationTypes < ActiveRecord::Migration
   def change
-    add_column :publication_types, :has_open_access, :boolean default: true
+    add_column :publication_types, :has_open_access, :boolean, default: true
   end
 end

--- a/db/migrate/20260422115400_add_oa_fields_to_publication_links.rb
+++ b/db/migrate/20260422115400_add_oa_fields_to_publication_links.rb
@@ -1,0 +1,6 @@
+class AddOaFieldsToPublicationLinks < ActiveRecord::Migration
+  def change
+    add_column :publication_links, :checked_at, :datetime
+    add_index :publication_links, :checked_at
+  end
+end

--- a/db/migrate/20260511115311_rename_oa_to_is_oa.rb
+++ b/db/migrate/20260511115311_rename_oa_to_is_oa.rb
@@ -1,0 +1,5 @@
+class RenameOaToIsOa < ActiveRecord::Migration
+  def change
+    rename_column :publication_links, :oa, :is_oa
+  end
+end

--- a/docker/build/.env
+++ b/docker/build/.env
@@ -1,2 +1,2 @@
 GIT_REPO_URL=https://github.com/ub-digit/gup.git
-GIT_REVISION=release-2021.06.002
+GIT_REVISION=test-radion-btns-for-oa-2026.05.001

--- a/frontend/app/components/multiple-items.js
+++ b/frontend/app/components/multiple-items.js
@@ -6,12 +6,6 @@ export default Ember.Component.extend({
   addItemText: null,
   deleteItemText: null,
   items: null,
-  sortedItems: Ember.computed('items.@each.position', function() {
-    return this.get('items').sortBy('position');
-  }),
-
- 
-
   totalNumberOfItems: Ember.computed('items.[]', function() {
     //TODO: double check, array length javscript weirdness etc
     return this.get('items').length;
@@ -43,32 +37,26 @@ export default Ember.Component.extend({
     //didAddItem etc??
     addItem: function() {
       let newItem = this.get('createNewItem')();
-      let lastItem = this.get('items').get('lastObject');
-      newItem.set('position', lastItem !== undefined ? lastItem.get('position') + 1 : 0);
+    //  let lastItem = this.get('items').get('lastObject');
+  //    newItem.set('position', lastItem !== undefined ? lastItem.get('position') + 1 : 0);
       this.get('items').pushObject(newItem);
     },
     removeItem: function(item) {
       this.get('items').removeObject(item);
     },
     didMoveItemUp: function(item) {
-      let sortedItems = this.get('sortedItems');
-      if (sortedItems.get('firstObject') !== item) {
-        let idx = sortedItems.indexOf(item);
-        let position = item.get('position');
-        let itemAbove = sortedItems.objectAt(idx - 1);
-        item.set('position', itemAbove.position);
-        itemAbove.set('position', position);
-      }
+      let index = this.get("items").indexOf(item);
+      if (index > 0) {
+        this.get("items").removeAt(index);
+        this.get("items").insertAt(index - 1, item);
+      } 
     },
     didMoveItemDown: function(item) {
-      let sortedItems = this.get('sortedItems');
-      if (sortedItems.get('lastObject') !== item) {
-        let idx = sortedItems.indexOf(item);
-        let position = item.get('position');
-        let itemBelow = sortedItems.objectAt(idx + 1);
-        item.set('position', itemBelow.position);
-        itemBelow.set('position', position);
-      }
+      let index = this.get("items").indexOf(item);
+      if (index < this.get("items").length - 1) {
+        this.get("items").removeAt(index);
+        this.get("items").insertAt(index + 1, item);
+      } 
     }
   }
 });

--- a/frontend/app/components/publication-list-row.js
+++ b/frontend/app/components/publication-list-row.js
@@ -11,6 +11,16 @@ export default Ember.Component.extend({
     return false;
   }),
 
+  hasOpenAccess: Ember.computed('item.open_access', function() {
+    //TBD: re-enable when open access is properly implemented
+    let oaLink = this.get('item.publication_links') ? this.get('item.publication_links').findBy('oa', true) : null;
+    if (oaLink) {
+      return true;
+    }
+    return false;
+
+  }),
+
   titleString: Ember.computed('item.title', function() {
     return this.get('item.title') || this.get('i18n').t('components.publicationListRow.noTitle');
   }),

--- a/frontend/app/components/publication-list-row.js
+++ b/frontend/app/components/publication-list-row.js
@@ -14,9 +14,16 @@ export default Ember.Component.extend({
   hasOpenAccess: Ember.computed('item.open_access', function() {
     //TBD: re-enable when open access is properly implemented
     let oaLink = this.get('item.publication_links') ? this.get('item.publication_links').findBy('oa', true) : null;
-    if (oaLink) {
+
+    if (oaLink && oaLink.oa === true) {
       return true;
     }
+
+    if (!oaLink) {
+
+      null;
+    }
+    
     return false;
 
   }),

--- a/frontend/app/components/publication-list-row.js
+++ b/frontend/app/components/publication-list-row.js
@@ -15,7 +15,7 @@ export default Ember.Component.extend({
     //TBD: re-enable when open access is properly implemented
     let oaLink = this.get('item.publication_links') ? this.get('item.publication_links').findBy('is_oa', true) : null;
 
-    if (oaLink && oaLink.oa === true) {
+    if (oaLink && oaLink.is_oa === true) {
       return true;
     }
 

--- a/frontend/app/components/publication-list-row.js
+++ b/frontend/app/components/publication-list-row.js
@@ -13,7 +13,7 @@ export default Ember.Component.extend({
 
   hasOpenAccess: Ember.computed('item.open_access', function() {
     //TBD: re-enable when open access is properly implemented
-    let oaLink = this.get('item.publication_links') ? this.get('item.publication_links').findBy('oa', true) : null;
+    let oaLink = this.get('item.publication_links') ? this.get('item.publication_links').findBy('is_oa', true) : null;
 
     if (oaLink && oaLink.oa === true) {
       return true;

--- a/frontend/app/controllers/publications/dashboard/manage/show/edit.js
+++ b/frontend/app/controllers/publications/dashboard/manage/show/edit.js
@@ -19,7 +19,9 @@ export default Ember.Controller.extend({
 
   createNewPublicationLink: function() {
     return Ember.Object.create({
+      id: Ember.guidFor({}),
       url: '',
+      oa: false
     });
   },
 

--- a/frontend/app/controllers/publications/dashboard/manage/show/edit.js
+++ b/frontend/app/controllers/publications/dashboard/manage/show/edit.js
@@ -21,7 +21,7 @@ export default Ember.Controller.extend({
     return Ember.Object.create({
       id: Ember.guidFor({}),
       url: '',
-      oa: false
+      oa: null
     });
   },
 
@@ -323,6 +323,32 @@ export default Ember.Controller.extend({
       // TODO: Not needed right now, refactor confirmation-modal not to set this internally since bad ember practice
       // and uncomment this line?
       //this.set('isShowingInvalidSelectedDepartmentsConfirmation', false);
+    },
+    setOpenAccess(publicationLink, value, publication) {
+     
+      if (!publicationLink) {
+        console.error("publicationLink is null");
+        return;
+      }
+       publicationLink.set('oa', value);
+      // const newValue = value === true || value === "true";
+
+      // console.log("setOpenAccess → link id:", publicationLink.id, "value:", newValue);
+
+      // // Set the value
+      // Ember.set(publicationLink, 'oa', newValue);
+
+      // // Force Ember to detect the change on the parent
+      // // const publication = this.get('publication');
+
+      if (publication && publication.publication_links) {
+        // This is the most reliable way in old Ember when dealing with arrays of plain objects
+        publication.set('publication_links', publication.get('publication_links').slice());
+        
+        console.log("✅ publication_links array refreshed");
+      } else {
+        console.warn("Could not find publication object");
+      }
     }
   }
 });

--- a/frontend/app/controllers/publications/dashboard/manage/show/edit.js
+++ b/frontend/app/controllers/publications/dashboard/manage/show/edit.js
@@ -21,7 +21,7 @@ export default Ember.Controller.extend({
     return Ember.Object.create({
       id: Ember.guidFor({}),
       url: '',
-      oa: null
+      is_oa: null
     });
   },
 
@@ -330,17 +330,7 @@ export default Ember.Controller.extend({
         console.error("publicationLink is null");
         return;
       }
-       publicationLink.set('oa', value);
-      // const newValue = value === true || value === "true";
-
-      // console.log("setOpenAccess → link id:", publicationLink.id, "value:", newValue);
-
-      // // Set the value
-      // Ember.set(publicationLink, 'oa', newValue);
-
-      // // Force Ember to detect the change on the parent
-      // // const publication = this.get('publication');
-
+       publicationLink.set('is_oa', value);
       if (publication && publication.publication_links) {
         // This is the most reliable way in old Ember when dealing with arrays of plain objects
         publication.set('publication_links', publication.get('publication_links').slice());

--- a/frontend/app/locales/en/translations.js
+++ b/frontend/app/locales/en/translations.js
@@ -487,8 +487,11 @@ export default {
         publicationLinksLabel: 'External links',
         publicationLinksAddItem: 'Add link',
         generalErrorHeader: 'The form contain errors. Please correct these and try again.',
+        publicationLinksOpenAccessLabel: 'OA',
+        publicationLinksOpenAccessLabelHelptext: 'Mark if the link leads to an open access version of the publication.',
         help: {
           publicationLinks: 'Links should begin with http:// or https://',
+          publicationLinksOpenAccess: 'Mark if the link leads to an open access version of the publication.',
           authors: {
             helptext: {
               general: 'Please register all authors in the same order as mentioned in the original publication. If the author is affiliated to GU, register family name and first name and <strong>the affiliation as it’s indicated in the publication</strong>. For other authors, register family name and first name’s initial. Please search for already registered authors before creating a new one.',

--- a/frontend/app/locales/en/translations.js
+++ b/frontend/app/locales/en/translations.js
@@ -487,7 +487,11 @@ export default {
         publicationLinksLabel: 'External links',
         publicationLinksAddItem: 'Add link',
         generalErrorHeader: 'The form contain errors. Please correct these and try again.',
-        publicationLinksOpenAccessLabel: 'OA',
+        publicationLinksOpenAccessLabels: {
+          label: 'OA',
+          yes: 'Yes',
+          no: 'No'
+        },
         publicationLinksOpenAccessLabelHelptext: 'Mark if the link leads to an open access version of the publication.',
         help: {
           publicationLinks: 'Links should begin with http:// or https://',

--- a/frontend/app/locales/en/translations.js
+++ b/frontend/app/locales/en/translations.js
@@ -490,7 +490,8 @@ export default {
         publicationLinksOpenAccessLabels: {
           label: 'OA',
           yes: 'Yes',
-          no: 'No'
+          no: 'No',
+          unknown: 'Unknown',
         },
         publicationLinksOpenAccessLabelHelptext: 'Mark if the link leads to an open access version of the publication.',
         help: {

--- a/frontend/app/locales/sv/translations.js
+++ b/frontend/app/locales/sv/translations.js
@@ -487,8 +487,11 @@ export default {
         publicationLinksLabel: 'Externa länkar',
         publicationLinksAddItem: 'Lägg till länk',
         generalErrorHeader: 'Formuläret innehåller felaktigheter. Var vänlig rätta till dessa och försök igen.',
+        publicationLinksOpenAccessLabel: 'OA',
+        publicationLinksOpenAccessLabelHelptext: 'Markera om länken leder till en open access-version av publikationen.',
         help: {
           publicationLinks: 'Länkar bör inledas med http:// eller https://',
+          publicationLinksOpenAccess: 'Markera om länken leder till en open access-version av publikationen.',
           authors: {
             helptext: {
               general: 'Ange samtliga författare i ordningsföljd enligt originalpublikationen. För GU-författare skriv fullständigt namn samt <strong>den affiliering som angivits i publikationen</strong>. För övriga författare är efternamn samt förnamnets initial tillräckligt. Sök bland författarna som redan finns inlagda innan du väljer att lägga till en ny.',

--- a/frontend/app/locales/sv/translations.js
+++ b/frontend/app/locales/sv/translations.js
@@ -490,7 +490,8 @@ export default {
         publicationLinksOpenAccessLabels: {
           label: 'OA',
           yes: 'Ja',
-          no: 'Nej'
+          no: 'Nej',
+          unknown: 'Vet ej'
         },
         publicationLinksOpenAccessLabelHelptext: 'Markera om länken leder till en open access-version av publikationen.',
         help: {

--- a/frontend/app/locales/sv/translations.js
+++ b/frontend/app/locales/sv/translations.js
@@ -487,7 +487,11 @@ export default {
         publicationLinksLabel: 'Externa länkar',
         publicationLinksAddItem: 'Lägg till länk',
         generalErrorHeader: 'Formuläret innehåller felaktigheter. Var vänlig rätta till dessa och försök igen.',
-        publicationLinksOpenAccessLabel: 'OA',
+        publicationLinksOpenAccessLabels: {
+          label: 'OA',
+          yes: 'Ja',
+          no: 'Nej'
+        },
         publicationLinksOpenAccessLabelHelptext: 'Markera om länken leder till en open access-version av publikationen.',
         help: {
           publicationLinks: 'Länkar bör inledas med http:// eller https://',

--- a/frontend/app/routes/publications/dashboard/manage/show/edit.js
+++ b/frontend/app/routes/publications/dashboard/manage/show/edit.js
@@ -39,7 +39,7 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, ResetScroll, {
     this._super(...arguments);
     //TODO: Remove this when binding issue fixed
     if (Ember.isBlank(models.publication.publication_links)) {
-      models.publication.publication_links = [{ url: "", position: 0 }];
+      models.publication.publication_links.pushObject(Ember.Object.create({ url: "", oa: false, id: Ember.guidFor({}) }));
       //models.publication.publication_links.pushObject({url: '', position: 0});
     }
 
@@ -208,6 +208,14 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, ResetScroll, {
         "controller.publication.publication_links",
         this.get("controller.publication.publication_links").filter((link) => {
           return Ember.isPresent(link.get("url"));
+        })
+      );
+
+      // Set positions according to current order
+      this.set("controller.publication.publication_links",
+        this.get("controller.publication.publication_links").map((link, index) => {
+            link.set("position", index);
+            return link;
         })
       );
 

--- a/frontend/app/routes/publications/dashboard/manage/show/edit.js
+++ b/frontend/app/routes/publications/dashboard/manage/show/edit.js
@@ -39,7 +39,7 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, ResetScroll, {
     this._super(...arguments);
     //TODO: Remove this when binding issue fixed
     if (Ember.isBlank(models.publication.publication_links)) {
-      models.publication.publication_links.pushObject(Ember.Object.create({ url: "", oa: false, id: Ember.guidFor({}) }));
+      models.publication.publication_links.pushObject(Ember.Object.create({ url: "", oa: null, id: Ember.guidFor({}) }));
       //models.publication.publication_links.pushObject({url: '', position: 0});
     }
 

--- a/frontend/app/templates/components/multiple-items.hbs
+++ b/frontend/app/templates/components/multiple-items.hbs
@@ -1,4 +1,4 @@
-{{#each sortedItems as |item index|}}
+{{#each items as |item index|}}
   {{yield
     item
     (hash

--- a/frontend/app/templates/components/publication-field-preview.hbs
+++ b/frontend/app/templates/components/publication-field-preview.hbs
@@ -19,7 +19,7 @@
     {{else if isTypeLinks}}
       <ul class="list-unstyled">
       {{#each fieldValue as |link|}}
-        <li><a href="{{link.url}}" target="_blank">{{link.url}}</a></li>
+        <li><a href="{{link.url}}" target="_blank">{{link.url}}</a> {{#if link.oa }} <span><img style="height:14px;" src="/img/Open_Access_logo_PLoS_white.svg" title="Open Access" alt="Open Access">  </span> {{/if}}</li>
       {{/each}}
       </ul>
 

--- a/frontend/app/templates/components/publication-field-preview.hbs
+++ b/frontend/app/templates/components/publication-field-preview.hbs
@@ -19,7 +19,7 @@
     {{else if isTypeLinks}}
       <ul class="list-unstyled">
       {{#each fieldValue as |link|}}
-        <li><a href="{{link.url}}" target="_blank">{{link.url}}</a> {{#if link.oa }} <span><img style="height:14px;" src="/img/Open_Access_logo_PLoS_white.svg" title="Open Access" alt="Open Access">  </span> {{/if}}</li>
+        <li><a href="{{link.url}}" target="_blank">{{link.url}}</a> {{#if link.is_oa }} <span><img style="height:14px;" src="/img/Open_Access_logo_PLoS_white.svg" title="Open Access" alt="Open Access">  </span> {{/if}}</li>
       {{/each}}
       </ul>
 

--- a/frontend/app/templates/components/publication-list-row.hbs
+++ b/frontend/app/templates/components/publication-list-row.hbs
@@ -1,7 +1,7 @@
 <div class="publication-list-row">
   <div class="row">
     <div class="col-xs-12">
-      <h3>{{#link-to link item.id (query-params other_version=null)}} {{titleString}}{{/link-to}}</h3>
+      <h3>{{#link-to link item.id (query-params other_version=null)}} {{titleString}} {{#if hasOpenAccess}} <span><img style="height:14px;" src="/img/Open_Access_logo_PLoS_white.svg" title="Open Access" alt="Open Access">  </span> {{/if}}{{/link-to}}</h3>
 
     </div>
     <div class="col-xs-12">

--- a/frontend/app/templates/publications/publicationtypes/form.hbs
+++ b/frontend/app/templates/publications/publicationtypes/form.hbs
@@ -210,22 +210,35 @@
     <section id="publication-links">
       <label class="control-label">{{t 'publications.publicationtypes.form.publicationLinksLabel'}}</label>
       <span class="help-block">{{t 'publications.publicationtypes.form.help.publicationLinks'}}</span>
+      {{#if getPublicationTypeObject.has_open_access}}
+      <span class="help-block">{{t 'publications.publicationtypes.form.help.publicationLinksOpenAccess'}}</span>
+      {{/if}}
       {{#multiple-items
         items=publication.publication_links
         createNewItem=createNewPublicationLink
         addItemText=(t 'publications.publicationtypes.form.publicationLinksAddItem')
         as |publication_link multipleItem|}}
         <div class="row">
-          <div class="col-xs-10">
+          <div class="col-xs-9">
             <div class="form-group">
               {{input
                 type="text"
                 class="form-control"
-                id=(concat "publication-url-" multipleItem.index)
+                id=(concat "publication-url-" publication_link.id)
                 focus-out=(action "sanitizePublicationLink" publication_link)
                 value=publication_link.url
               }}
             </div>
+          </div>
+          <div class="col-xs-1">
+            <!-- hide if no open access -->
+            {{#if getPublicationTypeObject.has_open_access}}
+              <div class="form-group">
+                {{input id=(concat "publication-url-oa-" publication_link.id) type="checkbox"  checked=publication_link.oa}}
+                <label title="{{t 'publications.publicationtypes.form.publicationLinksOpenAccessLabelHelptext'}}" for={{concat "publication-url-oa-" publication_link.id}} class="control-label">{{t 'publications.publicationtypes.form.publicationLinksOpenAccessLabel'}}
+                </label>
+              </div>
+            {{/if}}
           </div>
           <div class="col-xs-1">
             {{multipleItem.removeButton}}

--- a/frontend/app/templates/publications/publicationtypes/form.hbs
+++ b/frontend/app/templates/publications/publicationtypes/form.hbs
@@ -219,7 +219,7 @@
         addItemText=(t 'publications.publicationtypes.form.publicationLinksAddItem')
         as |publication_link multipleItem|}}
         <div class="row">
-          <div class="col-xs-7">
+          <div class="col-xs-6">
             <div class="form-group">
               {{input
                 type="text"
@@ -230,13 +230,13 @@
               }}
             </div>
           </div>
-          <div class="col-xs-3">
+          <div class="col-xs-4">
             <!-- hide if no open access -->
             <!-- ==================== OPEN ACCESS RADIOS ==================== -->
           {{#if getPublicationTypeObject.has_open_access}}
             <div class="form-group">
               <label class="control-label" style="padding-right: 10px;">
-              {{t 'publications.publicationtypes.form.publicationLinksOpenAccessLabels.label'}}:
+              {{t 'publications.publicationtypes.form.publicationLinksOpenAccessLabels.label'}}
               </label>
               <div class="radio" style="display: inline-block; margin-right: 15px; margin-top: 0px;">
               <label>
@@ -249,7 +249,7 @@
               </label>
               </div>
 
-              <div class="radio" style="display: inline-block; margin-top: 0px;">
+              <div class="radio" style="display: inline-block; margin-right: 15px; margin-top: 0px;">
               <label>
                 <input 
                 type="radio" 
@@ -257,6 +257,16 @@
                 checked={{eq publication_link.oa false}}
                 {{action "setOpenAccess" publication_link false publication on="change"}}>
                 {{t 'publications.publicationtypes.form.publicationLinksOpenAccessLabels.no'}}
+              </label>
+              </div>
+              <div class="radio" style="display: inline-block; margin-top: 0px;">
+              <label>
+                <input 
+                type="radio" 
+                name={{concat "oa-radio-" publication_link.id}}
+                checked={{eq publication_link.oa null}}
+                {{action "setOpenAccess" publication_link null publication on="change"}}>
+                {{t 'publications.publicationtypes.form.publicationLinksOpenAccessLabels.unknown'}}
               </label>
               </div>
               {{#if publication_link.oaHelptext}}

--- a/frontend/app/templates/publications/publicationtypes/form.hbs
+++ b/frontend/app/templates/publications/publicationtypes/form.hbs
@@ -219,7 +219,7 @@
         addItemText=(t 'publications.publicationtypes.form.publicationLinksAddItem')
         as |publication_link multipleItem|}}
         <div class="row">
-          <div class="col-xs-9">
+          <div class="col-xs-7">
             <div class="form-group">
               {{input
                 type="text"
@@ -230,15 +230,43 @@
               }}
             </div>
           </div>
-          <div class="col-xs-1">
+          <div class="col-xs-3">
             <!-- hide if no open access -->
-            {{#if getPublicationTypeObject.has_open_access}}
-              <div class="form-group">
-                {{input id=(concat "publication-url-oa-" publication_link.id) type="checkbox"  checked=publication_link.oa}}
-                <label title="{{t 'publications.publicationtypes.form.publicationLinksOpenAccessLabelHelptext'}}" for={{concat "publication-url-oa-" publication_link.id}} class="control-label">{{t 'publications.publicationtypes.form.publicationLinksOpenAccessLabel'}}
-                </label>
+            <!-- ==================== OPEN ACCESS RADIOS ==================== -->
+          {{#if getPublicationTypeObject.has_open_access}}
+            <div class="form-group">
+              <label class="control-label" style="padding-right: 10px;">
+              {{t 'publications.publicationtypes.form.publicationLinksOpenAccessLabels.label'}}:
+              </label>
+              <div class="radio" style="display: inline-block; margin-right: 15px; margin-top: 0px;">
+              <label>
+                <input 
+                type="radio" 
+                name={{concat "oa-radio-" publication_link.id}}
+                checked={{eq publication_link.oa true}}
+                {{action "setOpenAccess" publication_link true publication on="change"}}>
+                {{t 'publications.publicationtypes.form.publicationLinksOpenAccessLabels.yes'}}
+              </label>
               </div>
-            {{/if}}
+
+              <div class="radio" style="display: inline-block; margin-top: 0px;">
+              <label>
+                <input 
+                type="radio" 
+                name={{concat "oa-radio-" publication_link.id}}
+                checked={{eq publication_link.oa false}}
+                {{action "setOpenAccess" publication_link false publication on="change"}}>
+                {{t 'publications.publicationtypes.form.publicationLinksOpenAccessLabels.no'}}
+              </label>
+              </div>
+              {{#if publication_link.oaHelptext}}
+              <p class="help-block">
+                {{t 'publications.publicationtypes.form.publicationLinksOpenAccessLabelHelptext'}}
+              </p>
+              {{/if}}
+            </div>
+          {{/if}}
+            <!-- ==================== OPEN ACCESS RADIOS END ==================== -->
           </div>
           <div class="col-xs-1">
             {{multipleItem.removeButton}}

--- a/frontend/app/templates/publications/publicationtypes/form.hbs
+++ b/frontend/app/templates/publications/publicationtypes/form.hbs
@@ -233,7 +233,6 @@
           <div class="col-xs-4">
             <!-- hide if no open access -->
             <!-- ==================== OPEN ACCESS RADIOS ==================== -->
-            <span style="font-size: 30px">{{getPublicationTypeObject.has_open_access}}</span>
           {{#if getPublicationTypeObject.has_open_access}}
             <div class="form-group">
               <label class="control-label" style="padding-right: 10px;">
@@ -270,7 +269,7 @@
                 {{t 'publications.publicationtypes.form.publicationLinksOpenAccessLabels.unknown'}}
               </label>
               </div>
-              {{#if publication_link.is_oaHelptext}}
+              {{#if publication_link.oaHelptext}}
               <p class="help-block">
                 {{t 'publications.publicationtypes.form.publicationLinksOpenAccessLabelHelptext'}}
               </p>

--- a/frontend/app/templates/publications/publicationtypes/form.hbs
+++ b/frontend/app/templates/publications/publicationtypes/form.hbs
@@ -207,7 +207,7 @@
   </div>
   -->
   <span class="form-group {{if errors.links 'has-error'}}">
-    <section id="publication-links">
+    <section id="publication-links" style="margin-top: 20px;">
       <label class="control-label">{{t 'publications.publicationtypes.form.publicationLinksLabel'}}</label>
       <span class="help-block">{{t 'publications.publicationtypes.form.help.publicationLinks'}}</span>
       {{#if getPublicationTypeObject.has_open_access}}

--- a/frontend/app/templates/publications/publicationtypes/form.hbs
+++ b/frontend/app/templates/publications/publicationtypes/form.hbs
@@ -233,6 +233,7 @@
           <div class="col-xs-4">
             <!-- hide if no open access -->
             <!-- ==================== OPEN ACCESS RADIOS ==================== -->
+            <span style="font-size: 30px">{{getPublicationTypeObject.has_open_access}}</span>
           {{#if getPublicationTypeObject.has_open_access}}
             <div class="form-group">
               <label class="control-label" style="padding-right: 10px;">
@@ -243,7 +244,7 @@
                 <input 
                 type="radio" 
                 name={{concat "oa-radio-" publication_link.id}}
-                checked={{eq publication_link.oa true}}
+                checked={{eq publication_link.is_oa true}}
                 {{action "setOpenAccess" publication_link true publication on="change"}}>
                 {{t 'publications.publicationtypes.form.publicationLinksOpenAccessLabels.yes'}}
               </label>
@@ -254,7 +255,7 @@
                 <input 
                 type="radio" 
                 name={{concat "oa-radio-" publication_link.id}}
-                checked={{eq publication_link.oa false}}
+                checked={{eq publication_link.is_oa false}}
                 {{action "setOpenAccess" publication_link false publication on="change"}}>
                 {{t 'publications.publicationtypes.form.publicationLinksOpenAccessLabels.no'}}
               </label>
@@ -264,12 +265,12 @@
                 <input 
                 type="radio" 
                 name={{concat "oa-radio-" publication_link.id}}
-                checked={{eq publication_link.oa null}}
+                checked={{eq publication_link.is_oa null}}
                 {{action "setOpenAccess" publication_link null publication on="change"}}>
                 {{t 'publications.publicationtypes.form.publicationLinksOpenAccessLabels.unknown'}}
               </label>
               </div>
-              {{#if publication_link.oaHelptext}}
+              {{#if publication_link.is_oaHelptext}}
               <p class="help-block">
                 {{t 'publications.publicationtypes.form.publicationLinksOpenAccessLabelHelptext'}}
               </p>

--- a/frontend/public/img/Open_Access_logo_PLoS_white.svg
+++ b/frontend/public/img/Open_Access_logo_PLoS_white.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="1000" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <metadata><rdf:RDF><cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:creator>art designer at PLoS, modified by Wikipedia users Nina, Beao, JakobVoss, and AnonMoos</dc:creator>
+    <dc:description>Open Access logo, converted into svg, designed by PLoS. This version with transparent background.</dc:description>
+    <dc:source>http://commons.wikimedia.org/wiki/File:Open_Access_logo_PLoS_white.svg</dc:source>
+    <dc:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/"/>
+    <cc:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/"/>
+    <cc:attributionName>art designer at PLoS, modified by Wikipedia users Nina, Beao, JakobVoss, and AnonMoos</cc:attributionName>
+    <cc:attributionURL>http://www.plos.org/</cc:attributionURL>
+  </cc:Work></rdf:RDF></metadata>
+  <rect width="640" height="1000" fill="#ffffff"/>
+  <g stroke="#f68212" stroke-width="104.764" fill="none">
+    <path d="M111.387,308.135V272.408A209.21,209.214 0 0,1 529.807,272.408V530.834"/>
+    <circle cx="320.004" cy="680.729" r="256.083"/>
+  </g>
+  <circle fill="#f68212" cx="321.01" cy="681.659" r="86.4287"/>
+</svg>

--- a/lib/tasks/oa.rake
+++ b/lib/tasks/oa.rake
@@ -1,0 +1,83 @@
+namespace :oa do
+  desc "Check a batch of publication_links for OA status via Unpaywall"
+  task check_next_publication_link: :environment do
+    email = ENV["UNPAYWALL_EMAIL"] || ENV["EMAIL"] || "gup@ub.gu.se"
+    batch_size = (ENV["BATCH"] || "100").to_i
+    batch_size = 10 if batch_size <= 0
+
+    recent_threshold = Time.current - 1.day
+
+    candidates = PublicationLink
+      .where("oa <> true OR oa IS NULL")
+      .where("publication_version_id IN (SELECT current_version_id FROM publications)")
+      .where("url ~* ?", '10\.\d+/')
+      .where("checked_at IS NULL OR checked_at < ?", recent_threshold)
+      .order(id: :desc)
+      .limit(batch_size)
+
+    processed = 0
+
+    puts "----------"
+    puts "Checking OA status at #{Time.current.iso8601}"
+    puts candidates.to_sql
+    puts "batch_size=#{batch_size}"
+
+    candidates.each do |publication_link|
+      break if processed >= batch_size
+
+      next if publication_link.oa == true
+      next if publication_link.checked_at.present? &&
+              publication_link.checked_at >= recent_threshold
+
+      doi = Unpaywall.extract_doi(publication_link.url)
+      next if doi.blank?
+
+      puts
+      puts "publication_link.id=#{publication_link.id}"
+      puts "url=#{publication_link.url}"
+      puts "doi=#{doi}"
+
+      oa_status = Unpaywall.oa_status_for_doi(doi, email: email)
+      now = Time.current
+
+      if oa_status == "error"
+        puts "Skipping publication_link #{publication_link.id} due to network/API error."
+        next
+      end
+
+      case oa_status
+      when true
+        publication_link.update!(
+          oa: true,
+          checked_at: now
+        )
+        puts "publication_link #{publication_link.id} set to OA"
+
+      when false
+        publication_link.update!(
+          oa: false,
+          checked_at: now
+        )
+        puts "publication_link #{publication_link.id} set to not OA"
+
+      when "unknown"
+        publication_link.update!(
+          checked_at: now
+        )
+        puts "publication_link #{publication_link.id} not found in Unpaywall"
+      end
+
+      pub_id = publication_link.publication_version.publication_id
+      puts "Indexing publication #{pub_id}..."
+      GupAdminPublication.put_to_index(pub_id)
+
+      processed += 1
+      puts "Processed #{processed} records so far..."
+
+      sleep 0.2
+    end
+
+    puts
+    puts "Processed #{processed} records."
+  end
+end

--- a/lib/tasks/oa.rake
+++ b/lib/tasks/oa.rake
@@ -2,13 +2,13 @@ namespace :oa do
   desc "Check a batch of publication_links for OA status via Unpaywall"
   task check_next_publication_link: :environment do
     email = ENV["UNPAYWALL_EMAIL"] || ENV["EMAIL"] || "gup@ub.gu.se"
-    batch_size = (ENV["BATCH"] || "100").to_i
-    batch_size = 10 if batch_size <= 0
+    batch_size = (ENV["BATCH"] || "1000").to_i
+    batch_size = 1000 if batch_size <= 0
 
-    recent_threshold = Time.current - 1.day
+    recent_threshold = Time.current - 1.month
 
     candidates = PublicationLink
-      .where("oa <> true OR oa IS NULL")
+      .where("is_oa <> true OR is_oa IS NULL")
       .where("publication_version_id IN (SELECT current_version_id FROM publications)")
       .where("url ~* ?", '10\.\d+/')
       .where("checked_at IS NULL OR checked_at < ?", recent_threshold)
@@ -20,12 +20,12 @@ namespace :oa do
     puts "----------"
     puts "Checking OA status at #{Time.current.iso8601}"
     puts candidates.to_sql
-    puts "batch_size=#{batch_size}"
+    puts "batch_size=#{batch_size} (maximum)"
 
     candidates.each do |publication_link|
       break if processed >= batch_size
 
-      next if publication_link.oa == true
+      next if publication_link.is_oa == true
       next if publication_link.checked_at.present? &&
               publication_link.checked_at >= recent_threshold
 
@@ -48,14 +48,14 @@ namespace :oa do
       case oa_status
       when true
         publication_link.update!(
-          oa: true,
+          is_oa: true,
           checked_at: now
         )
         puts "publication_link #{publication_link.id} set to OA"
 
       when false
         publication_link.update!(
-          oa: false,
+          is_oa: false,
           checked_at: now
         )
         puts "publication_link #{publication_link.id} set to not OA"


### PR DESCRIPTION
label for oa-checkbox

prints OA info if true

adds checkbox for oa

adds oa:false to publication_links

form edit

adds OA in permit

adds publicationLinksOpenAccessLabelHelptext if needed

migration adding column for oa in publication_types

sort desc

adds default to mig

oa-icon added to project

fixes for oa

removes brief=true to get publication_links in result set

check if at least one link is OA

make findBy call safe

new info text for links if openaccess is enabled for type